### PR TITLE
Added $doc modifier support to `RemoveModifiers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ By default, [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) will igno
 Here is the list of modifiers that will be removed:
 
 - `$third-party` and `$3p` modifiers
-- `$document` modifier
+- `$document` and `$doc` modifiers
 - `$all` modifier
 - `$popup` modifier
 

--- a/src/transformations/remove-modifiers.js
+++ b/src/transformations/remove-modifiers.js
@@ -4,7 +4,7 @@ const ruleUtils = require('../rule');
 
 /**
  * This transformation simply removes the following modifiers from the adblock-style rules:
- * $document, $all, $third-party, $3p, $popup
+ * $document, $doc, $all, $third-party, $3p, $popup
  *
  * @param {Array<string>} rules - rules to transform
  * @returns {Array<string>} filtered rules
@@ -32,6 +32,7 @@ function removeModifiers(rules) {
         modified = ruleUtils.removeModifier(props, '3p') || modified;
         modified = ruleUtils.removeModifier(props, 'all') || modified;
         modified = ruleUtils.removeModifier(props, 'document') || modified;
+        modified = ruleUtils.removeModifier(props, 'doc') || modified;
         modified = ruleUtils.removeModifier(props, 'popup') || modified;
         filtered.push(ruleUtils.adblockRuleToString(props));
 

--- a/test/transformations/remove-modifiers.test.js
+++ b/test/transformations/remove-modifiers.test.js
@@ -7,17 +7,19 @@ describe('Strip third-party', () => {
 ||example.net$domain=ya.ru,3p
 ||islandofadvert.com^$document,popup
 ||example.com$document
+||example.com$doc
 ||example.com$all
 ||example.org^`.split(/\r?\n/);
         const filtered = removeModifiers(rules);
 
-        expect(filtered).toHaveLength(7);
+        expect(filtered).toHaveLength(8);
         expect(filtered[0]).toBe('! test comment');
         expect(filtered[1]).toBe('||example.org$important');
         expect(filtered[2]).toBe('||example.net$domain=ya.ru');
         expect(filtered[3]).toBe('||islandofadvert.com^');
         expect(filtered[4]).toBe('||example.com');
         expect(filtered[5]).toBe('||example.com');
-        expect(filtered[6]).toBe('||example.org^');
+        expect(filtered[6]).toBe('||example.com');
+        expect(filtered[7]).toBe('||example.org^');
     });
 });


### PR DESCRIPTION
`$document` alias
<https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#document>

**ATTENTION**
I am not quite aware of any effect of this change on the output of [AdGuardSDNSFilter](https://github.com/AdguardTeam/AdGuardSDNSFilter).