### PR TITLE
TS declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.13",
   "description": "A simple tool that compiles hosts blocklists from multiple sources",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "repository": "https://github.com/AdguardTeam/HostlistCompiler",
   "author": "AdGuard",
   "license": "GPL-3.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,52 @@
+declare module '@adguard/hostlist-compiler' {
+    export type SourceType = 'adblock' | 'hosts';
+    export type Transformation = 'RemoveComments' | 'Compress' | 'RemoveModifiers' | 'Validate' | 'Deduplicate' | 'InvertAllow';
+
+    /** A source for the filter list */
+    export interface ISource {
+        /** Name of the source */
+        name?: string;
+        /** Path to a file or a URL */
+        source: string;
+        /** Type of the source */
+        type?: SourceType;
+        /** A list of the transformations that will be applied */
+        transformations?: Transformation[];
+        /** A list of rules (or wildcards) to exclude from the source. */
+        exclusions?: string[];
+        /** An array of exclusions sources. */
+        exclusions_sources?: string[];
+        /** A list of wildcards to include from the source. All rules that don't match these wildcards won't be included. */
+        inclusions?: string[];
+        /** A list of files with inclusions. */
+        inclusions_sources?: string[];
+    }
+
+    /** Configuration for the hostlist compiler */
+    export interface IConfiguration {
+        /** Filter list name */
+        name: string;
+        /** Filter list description */
+        description?: string;
+        /** Filter list homepage */
+        homepage?: string;
+        /** Filter list license */
+        license?: string;
+        /** An array of the filter list sources */
+        sources: ISource[];
+        /** A list of the transformations that will be applied */
+        transformations?: Transformation[];
+        /** A list of rules (or wildcards) to exclude from the source. */
+        exclusions?: string[];
+        /** An array of exclusions sources. */
+        exclusions_sources?: string[];
+        /** A list of wildcards to include from the source. All rules that don't match these wildcards won't be included. */
+        inclusions?: string[];
+        /** A list of files with inclusions. */
+        inclusions_sources?: string[];
+    }
+
+    declare async function compile(configuration: IConfiguration): Promise<string[]>;
+
+    export default compile;
+}


### PR DESCRIPTION
TS declarations for the Hostlist Compiler.

Example usage (`hostlist.ts`):
```ts
import HostlistCompiler, { IConfiguration as HostlistCompilerConfiguration } from '@adguard/hostlist-compiler';
import { writeFileSync } from 'fs';

(async () => {
    // Configuration
    const config: HostlistCompilerConfiguration = {
        name: 'hufilter DNS filter',
        description: 'Simplified hufilter version specifically to be better compatible with DNS-level ad blocking.',
        homepage: 'https://github.com/hufilter/hufilter/wiki',
        license: 'https://github.com/hufilter/hufilter/blob/master/LICENSE',
        sources: [
            {
                type: 'adblock',
                source: 'https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-adguard.txt',
                transformations: ['RemoveComments', 'Validate', 'Deduplicate'],
            },
        ],
    };

    // Compiled filter list
    const result = await HostlistCompiler(config);

    // Write it to file
    writeFileSync('hufilter-dns.txt', result.join('\n'));
})();
```

VSCode suggestions:
- Possible values:
  ![Code_iPT6sLEOMt](https://user-images.githubusercontent.com/57285466/171641898-5732d394-dd82-4e58-8cf2-7aa4b8f4dc7d.png)
- Basic JSDoc:
  ![Code_V0ByDzPk2E](https://user-images.githubusercontent.com/57285466/171641921-bf98a047-d6a7-43b5-abe8-95ee903c368d.png)
