### PR TITLE
Attempting to fix #42

### DIFF
--- a/src/transformations/validate.js
+++ b/src/transformations/validate.js
@@ -12,6 +12,7 @@ const SUPPORTED_MODIFIERS = [
     '~important',
     'badfilter',
     'ctag',
+    'denyallow',
 ];
 
 /**


### PR DESCRIPTION
I attempted to figure out the hostfiles generation system for some 3 hours or so, and this was the closest I came to anything that'd come close to making `$denyallow` work in included lists, especially since HostlistsRegistry lacks `diff.txt` files.