### PR TITLE
Fix https://github.com/AdguardTeam/AdguardFilters/issues/184671 + Partially handling #69

### DIFF
--- a/src/transformations/remove-modifiers.js
+++ b/src/transformations/remove-modifiers.js
@@ -35,6 +35,7 @@ function removeModifiers(rules) {
         modified = ruleUtils.removeModifier(props, 'document') || modified;
         modified = ruleUtils.removeModifier(props, 'doc') || modified;
         modified = ruleUtils.removeModifier(props, 'popup') || modified;
+        modified = ruleUtils.removeModifier(props, 'network') || modified;
         filtered.push(ruleUtils.adblockRuleToString(props));
 
         if (modified) {


### PR DESCRIPTION
Making it so that the entry/entries discussed in https://github.com/AdguardTeam/AdguardFilters/issues/184671 would be automatically added to AdGuard DNS Filter.

And from what I personally understood of https://github.com/AdguardTeam/HostlistCompiler/issues/69#issue-2450757000, @Alex-302 would almost certainly attest to the overall situation too.